### PR TITLE
feat(client): add explanation popup with pedagogical feedback flow (ME-30, ME-29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ yarn-error.log*
 *.cer
 *.p12
 *.pfx
+
+# Local temp files (tutorials, notes, etc.)
+/temp/

--- a/Client/Assets/Scripts/Managers/GameManager.cs
+++ b/Client/Assets/Scripts/Managers/GameManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using Data.Exercises;
+using UI;
 using UI.Exercises;
 using UnityEngine;
 
@@ -37,6 +38,7 @@ namespace Managers
 
         // Exercise system state
         private ExerciseUIController _exerciseUIController;
+        private ExplanationPopupController _explanationPopup;
         private LevelData _currentLevelData;
         private List<BaseExerciseData> _currentExercises;
         private int _currentExerciseIndex;
@@ -129,6 +131,13 @@ namespace Managers
             _exerciseUIController = controller;
             _exerciseUIController.OnAnswerSubmitted += HandleAnswerSubmitted;
 
+            // Get the explanation popup reference
+            _explanationPopup = controller.GetExplanationPopup();
+            if (_explanationPopup == null)
+            {
+                Debug.LogWarning("[GameManager] ExplanationPopupController not found on ExerciseUIController. Explanations will be skipped.");
+            }
+
             Debug.Log("[GameManager] ExerciseUIController registered.");
 
             // Start gameplay if exercises are loaded
@@ -209,6 +218,9 @@ namespace Managers
                 audioManager.PlaySound(isCorrect ? correctSoundName : incorrectSoundName);
             }
 
+            // Show visual feedback on the exercise panel (correct/incorrect highlighting)
+            _exerciseUIController?.ShowFeedback(isCorrect);
+
             if (!isCorrect)
             {
                 _currentLives--;
@@ -221,20 +233,33 @@ namespace Managers
 
                 if (_currentLives <= 0)
                 {
-                    StartCoroutine(WaitAndGameOver());
+                    StartCoroutine(ShowFeedbackAndGameOver(exercise, isCorrect));
                     return;
                 }
             }
 
-            StartCoroutine(WaitAndLoadNextExercise());
+            StartCoroutine(ShowFeedbackAndAdvance(exercise, isCorrect));
         }
 
         /// <summary>
-        /// Waits for feedback delay then loads next exercise.
+        /// Shows the explanation popup, waits for dismissal, then loads the next exercise.
+        /// Falls back to a timed delay if no popup is configured.
         /// </summary>
-        private IEnumerator WaitAndLoadNextExercise()
+        private IEnumerator ShowFeedbackAndAdvance(BaseExerciseData exercise, bool isCorrect)
         {
-            yield return new WaitForSeconds(feedbackDelay);
+            if (_explanationPopup != null && !string.IsNullOrEmpty(exercise.explanation))
+            {
+                // Wait briefly so the player sees the visual feedback before the popup
+                yield return new WaitForSeconds(0.5f);
+
+                _explanationPopup.Show(exercise.explanation, isCorrect);
+                yield return new WaitUntil(() => !_explanationPopup.IsVisible());
+            }
+            else
+            {
+                // Fallback: use the fixed delay if no popup is available
+                yield return new WaitForSeconds(feedbackDelay);
+            }
 
             _exerciseUIController?.ResetCurrentPanel();
             _currentExerciseIndex++;
@@ -250,11 +275,22 @@ namespace Managers
         }
 
         /// <summary>
-        /// Waits for feedback delay then triggers game over.
+        /// Shows the explanation popup, waits for dismissal, then triggers game over.
+        /// Falls back to a timed delay if no popup is configured.
         /// </summary>
-        private IEnumerator WaitAndGameOver()
+        private IEnumerator ShowFeedbackAndGameOver(BaseExerciseData exercise, bool isCorrect)
         {
-            yield return new WaitForSeconds(feedbackDelay);
+            if (_explanationPopup != null && !string.IsNullOrEmpty(exercise.explanation))
+            {
+                yield return new WaitForSeconds(0.5f);
+
+                _explanationPopup.Show(exercise.explanation, isCorrect);
+                yield return new WaitUntil(() => !_explanationPopup.IsVisible());
+            }
+            else
+            {
+                yield return new WaitForSeconds(feedbackDelay);
+            }
 
             Debug.Log("[GameManager] Game Over!");
             OnGameOver();
@@ -349,6 +385,8 @@ namespace Managers
                 _exerciseUIController.OnAnswerSubmitted -= HandleAnswerSubmitted;
                 _exerciseUIController = null;
             }
+
+            _explanationPopup = null;
 
             sceneManager?.LoadScene(mainMenuSceneName);
         }

--- a/Client/Assets/Scripts/UI/Exercises/ExerciseUIController.cs
+++ b/Client/Assets/Scripts/UI/Exercises/ExerciseUIController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Data.Exercises;
+using UI;
 using UnityEngine;
 
 namespace UI.Exercises
@@ -26,6 +27,10 @@ namespace UI.Exercises
 
         [Tooltip("Reference to the Matching panel controller")]
         [SerializeField] private MatchingController matchingController;
+
+        [Header("Feedback")]
+        [Tooltip("Reference to the explanation popup controller")]
+        [SerializeField] private ExplanationPopupController explanationPopup;
 
         /// <summary>
         /// Event triggered when an answer is submitted by any exercise controller.
@@ -151,6 +156,14 @@ namespace UI.Exercises
         public void ShowFeedback(bool isCorrect, object correctAnswer = null)
         {
             _currentController?.ShowFeedback(isCorrect, correctAnswer);
+        }
+
+        /// <summary>
+        /// Gets the explanation popup controller.
+        /// </summary>
+        public ExplanationPopupController GetExplanationPopup()
+        {
+            return explanationPopup;
         }
 
         /// <summary>

--- a/Client/Assets/Scripts/UI/ExplanationPopupController.cs
+++ b/Client/Assets/Scripts/UI/ExplanationPopupController.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+namespace UI
+{
+    /// <summary>
+    /// Controls the explanation popup that appears after a player answers an exercise.
+    /// Displays pedagogical feedback explaining why an answer is correct or incorrect.
+    /// </summary>
+    public class ExplanationPopupController : MonoBehaviour
+    {
+        [Header("Panel References")]
+        [Tooltip("Root GameObject for the entire popup (overlay + content)")]
+        [SerializeField] private GameObject panelRoot;
+
+        [Tooltip("CanvasGroup used for fade-in/out animation")]
+        [SerializeField] private CanvasGroup canvasGroup;
+
+        [Header("Content References")]
+        [Tooltip("Title text (e.g., 'Bonne reponse !' or 'Mauvaise reponse')")]
+        [SerializeField] private TMP_Text titleText;
+
+        [Tooltip("Body text displaying the exercise explanation")]
+        [SerializeField] private TMP_Text explanationText;
+
+        [Tooltip("Button to dismiss the popup and continue")]
+        [SerializeField] private Button continueButton;
+
+        [Tooltip("Optional icon displayed next to the title")]
+        [SerializeField] private Image iconImage;
+
+        [Header("Correct Answer Settings")]
+        [Tooltip("Title displayed when the answer is correct")]
+        [SerializeField] private string correctTitle = "Bonne reponse !";
+
+        [Tooltip("Title displayed when the answer is incorrect")]
+        [SerializeField] private string incorrectTitle = "Mauvaise reponse";
+
+        [Tooltip("Color for the title when correct")]
+        [SerializeField] private Color correctColor = new Color(0.2f, 0.8f, 0.2f);
+
+        [Tooltip("Color for the title when incorrect")]
+        [SerializeField] private Color incorrectColor = new Color(0.9f, 0.2f, 0.2f);
+
+        [Tooltip("Optional sprite for correct answer")]
+        [SerializeField] private Sprite correctIcon;
+
+        [Tooltip("Optional sprite for incorrect answer")]
+        [SerializeField] private Sprite incorrectIcon;
+
+        [Header("Animation Settings")]
+        [Tooltip("Duration of the fade-in/out animation in seconds")]
+        [SerializeField] private float fadeDuration = 0.3f;
+
+        /// <summary>
+        /// Event fired when the player dismisses the popup.
+        /// Subscribe to this event to resume the game flow.
+        /// </summary>
+        public event Action OnPopupDismissed;
+
+        private Coroutine _fadeCoroutine;
+
+        private void Awake()
+        {
+            if (continueButton != null)
+            {
+                continueButton.onClick.AddListener(OnContinueClicked);
+            }
+
+            // Ensure popup is hidden at start
+            HideImmediate();
+        }
+
+        /// <summary>
+        /// Shows the explanation popup with the given text and correct/incorrect state.
+        /// </summary>
+        /// <param name="explanation">The explanation text from BaseExerciseData</param>
+        /// <param name="wasCorrect">Whether the player's answer was correct</param>
+        public void Show(string explanation, bool wasCorrect)
+        {
+            if (panelRoot == null)
+            {
+                Debug.LogError("[ExplanationPopupController] panelRoot is null!");
+                return;
+            }
+
+            // Set title
+            if (titleText != null)
+            {
+                titleText.text = wasCorrect ? correctTitle : incorrectTitle;
+                titleText.color = wasCorrect ? correctColor : incorrectColor;
+            }
+
+            // Set explanation body
+            if (explanationText != null)
+            {
+                explanationText.text = explanation ?? "";
+            }
+
+            // Set icon
+            if (iconImage != null)
+            {
+                Sprite icon = wasCorrect ? correctIcon : incorrectIcon;
+                if (icon != null)
+                {
+                    iconImage.sprite = icon;
+                    iconImage.color = wasCorrect ? correctColor : incorrectColor;
+                    iconImage.gameObject.SetActive(true);
+                }
+                else
+                {
+                    iconImage.gameObject.SetActive(false);
+                }
+            }
+
+            // Show with fade-in
+            panelRoot.SetActive(true);
+            FadeIn();
+
+            Debug.Log($"[ExplanationPopupController] Showing explanation (correct: {wasCorrect})");
+        }
+
+        /// <summary>
+        /// Hides the popup with a fade-out animation and fires the OnPopupDismissed event.
+        /// </summary>
+        public void Hide()
+        {
+            if (_fadeCoroutine != null)
+            {
+                StopCoroutine(_fadeCoroutine);
+            }
+
+            _fadeCoroutine = StartCoroutine(FadeOutAndHide());
+        }
+
+        /// <summary>
+        /// Checks whether the popup is currently visible.
+        /// </summary>
+        public bool IsVisible()
+        {
+            return panelRoot != null && panelRoot.activeSelf;
+        }
+
+        /// <summary>
+        /// Called when the Continue button is clicked.
+        /// </summary>
+        private void OnContinueClicked()
+        {
+            Debug.Log("[ExplanationPopupController] Continue clicked, dismissing popup");
+            Hide();
+        }
+
+        /// <summary>
+        /// Starts the fade-in animation.
+        /// </summary>
+        private void FadeIn()
+        {
+            if (_fadeCoroutine != null)
+            {
+                StopCoroutine(_fadeCoroutine);
+            }
+
+            if (canvasGroup != null)
+            {
+                _fadeCoroutine = StartCoroutine(FadeCanvasGroup(0f, 1f, fadeDuration));
+            }
+        }
+
+        /// <summary>
+        /// Fades out the popup, hides it, and fires the dismissed event.
+        /// </summary>
+        private IEnumerator FadeOutAndHide()
+        {
+            if (canvasGroup != null)
+            {
+                yield return FadeCanvasGroup(1f, 0f, fadeDuration);
+            }
+
+            HideImmediate();
+            OnPopupDismissed?.Invoke();
+        }
+
+        /// <summary>
+        /// Animates the CanvasGroup alpha from one value to another.
+        /// </summary>
+        private IEnumerator FadeCanvasGroup(float from, float to, float duration)
+        {
+            if (canvasGroup == null)
+            {
+                yield break;
+            }
+
+            canvasGroup.alpha = from;
+            float elapsed = 0f;
+
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(elapsed / duration);
+                canvasGroup.alpha = Mathf.Lerp(from, to, t);
+                yield return null;
+            }
+
+            canvasGroup.alpha = to;
+        }
+
+        /// <summary>
+        /// Immediately hides the popup without animation.
+        /// </summary>
+        private void HideImmediate()
+        {
+            if (panelRoot != null)
+            {
+                panelRoot.SetActive(false);
+            }
+
+            if (canvasGroup != null)
+            {
+                canvasGroup.alpha = 0f;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (continueButton != null)
+            {
+                continueButton.onClick.RemoveListener(OnContinueClicked);
+            }
+
+            OnPopupDismissed = null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **New**: `ExplanationPopupController.cs` — Canvas-based popup that displays exercise explanations with fade-in/fade-out animation and a "Continuer" button
- **Modified**: `GameManager.cs` — Integrated the feedback flow: after answering, `ShowFeedback()` is called on the exercise panel, then the explanation popup appears. Falls back to a 2s delay if no popup is configured
- **Modified**: `ExerciseUIController.cs` — Added `ExplanationPopupController` SerializeField reference and `GetExplanationPopup()` accessor
- **Housekeeping**: `.gitignore` updated with `/temp/` entry for local-only files

## Flow change

**Before**: answer → audio → lives update → fixed 2s delay → next exercise  
**After**: answer → audio → ShowFeedback() on panel → lives update → 0.5s delay → explanation popup fades in → player reads → clicks "Continuer" → popup fades out → next exercise

## Unity Editor setup required

After merging, the popup GameObjects need to be created in the Game scene manually (Canvas + Panel + TextMeshPro + Button). A setup tutorial is available locally in `temp/tuto-explanation-popup.md`.

Closes ME-30, ME-29