### PR TITLE
feat(client): add login/register screens with JWT auth flow (ME-10)

### DIFF
--- a/Client/Assets/Scripts/Data/AuthDtos.cs
+++ b/Client/Assets/Scripts/Data/AuthDtos.cs
@@ -1,0 +1,55 @@
+namespace Data
+{
+    /// <summary>
+    /// Request body for POST /api/auth/login.
+    /// </summary>
+    [System.Serializable]
+    public class LoginRequestDto
+    {
+        public string email;
+        public string password;
+    }
+
+    /// <summary>
+    /// Request body for POST /api/auth/register.
+    /// </summary>
+    [System.Serializable]
+    public class RegisterRequestDto
+    {
+        public string email;
+        public string username;
+        public string password;
+    }
+
+    /// <summary>
+    /// Response body from POST /api/auth/login and POST /api/auth/register.
+    /// Contains the JWT token and user information.
+    /// </summary>
+    [System.Serializable]
+    public class AuthResponseDto
+    {
+        public string token;
+        public UserResponseDto user;
+    }
+
+    /// <summary>
+    /// User information returned from auth endpoints.
+    /// </summary>
+    [System.Serializable]
+    public class UserResponseDto
+    {
+        public string id;
+        public string email;
+        public string username;
+        public string createdAt;
+    }
+
+    /// <summary>
+    /// Error response from the API.
+    /// </summary>
+    [System.Serializable]
+    public class ErrorResponseDto
+    {
+        public string error;
+    }
+}

--- a/Client/Assets/Scripts/Managers/AuthManager.cs
+++ b/Client/Assets/Scripts/Managers/AuthManager.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Data;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Managers
+{
+    /// <summary>
+    /// Manages user authentication against the Go API.
+    /// Handles login, registration, token persistence, and auto-login.
+    /// Implements the Singleton pattern and persists across scene loads.
+    /// </summary>
+    public class AuthManager : MonoBehaviour
+    {
+        public static AuthManager Instance { get; private set; }
+
+        [Header("API Configuration")]
+        [SerializeField] private string apiBaseUrl = "http://localhost:8080";
+
+        private const string TOKEN_KEY = "AuthToken";
+        private const string USER_JSON_KEY = "AuthUser";
+
+        private string _token;
+        private UserResponseDto _currentUser;
+
+        /// <summary>
+        /// The current JWT token, or null if not authenticated.
+        /// </summary>
+        public string Token => _token;
+
+        /// <summary>
+        /// The currently authenticated user, or null if not authenticated.
+        /// </summary>
+        public UserResponseDto CurrentUser => _currentUser;
+
+        /// <summary>
+        /// Whether the user is currently authenticated (has a stored token).
+        /// </summary>
+        public bool IsAuthenticated => !string.IsNullOrEmpty(_token);
+
+        /// <summary>
+        /// Event raised when authentication state changes (login or logout).
+        /// </summary>
+        public event Action<bool> OnAuthStateChanged;
+
+        #region Singleton Setup
+
+        private void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+
+                if (transform.parent != null)
+                {
+                    transform.SetParent(null);
+                    Debug.LogWarning("[AuthManager] Was not at root level. Moved automatically.");
+                }
+
+                DontDestroyOnLoad(gameObject);
+
+                LoadTokenFromPrefs();
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Attempts to log in with email and password.
+        /// On success, stores the JWT token and user data.
+        /// </summary>
+        /// <param name="email">User email address.</param>
+        /// <param name="password">User password.</param>
+        /// <returns>Null on success, or an error message string on failure.</returns>
+        public async Task<string> LoginAsync(string email, string password)
+        {
+            var requestDto = new LoginRequestDto
+            {
+                email = email,
+                password = password
+            };
+
+            string json = JsonUtility.ToJson(requestDto);
+            string url = $"{apiBaseUrl}/api/auth/login";
+
+            Debug.Log($"[AuthManager] Logging in as {email}...");
+
+            return await SendAuthRequestAsync(url, json);
+        }
+
+        /// <summary>
+        /// Attempts to register a new account.
+        /// On success, stores the JWT token and user data (auto-login after register).
+        /// </summary>
+        /// <param name="email">User email address.</param>
+        /// <param name="username">Display username (min 3 characters).</param>
+        /// <param name="password">User password (min 8 characters).</param>
+        /// <returns>Null on success, or an error message string on failure.</returns>
+        public async Task<string> RegisterAsync(string email, string username, string password)
+        {
+            var requestDto = new RegisterRequestDto
+            {
+                email = email,
+                username = username,
+                password = password
+            };
+
+            string json = JsonUtility.ToJson(requestDto);
+            string url = $"{apiBaseUrl}/api/auth/register";
+
+            Debug.Log($"[AuthManager] Registering {username} ({email})...");
+
+            return await SendAuthRequestAsync(url, json);
+        }
+
+        /// <summary>
+        /// Logs out the current user. Clears token and user data from memory and PlayerPrefs.
+        /// </summary>
+        public void Logout()
+        {
+            Debug.Log("[AuthManager] Logging out...");
+
+            _token = null;
+            _currentUser = null;
+
+            PlayerPrefs.DeleteKey(TOKEN_KEY);
+            PlayerPrefs.DeleteKey(USER_JSON_KEY);
+            PlayerPrefs.Save();
+
+            OnAuthStateChanged?.Invoke(false);
+        }
+
+        /// <summary>
+        /// Checks if a saved token exists in PlayerPrefs.
+        /// Does not validate token expiry (MVP behavior).
+        /// </summary>
+        /// <returns>True if a token was loaded from PlayerPrefs.</returns>
+        public bool TryAutoLogin()
+        {
+            return IsAuthenticated;
+        }
+
+        #endregion
+
+        #region HTTP Helpers
+
+        /// <summary>
+        /// Sends a POST request to an auth endpoint and processes the response.
+        /// On success, saves the token and user data.
+        /// </summary>
+        /// <param name="url">Full API URL.</param>
+        /// <param name="jsonBody">JSON request body.</param>
+        /// <returns>Null on success, or an error message string on failure.</returns>
+        private async Task<string> SendAuthRequestAsync(string url, string jsonBody)
+        {
+            using (var request = new UnityWebRequest(url, "POST"))
+            {
+                byte[] bodyRaw = Encoding.UTF8.GetBytes(jsonBody);
+                request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+                request.downloadHandler = new DownloadHandlerBuffer();
+                request.SetRequestHeader("Content-Type", "application/json");
+
+                var operation = request.SendWebRequest();
+
+                while (!operation.isDone)
+                {
+                    await Task.Yield();
+                }
+
+                if (request.result == UnityWebRequest.Result.ConnectionError)
+                {
+                    Debug.LogError($"[AuthManager] Network error: {request.error}");
+                    return "Erreur de connexion au serveur. Vérifiez votre connexion internet.";
+                }
+
+                string responseJson = request.downloadHandler.text;
+
+                if (request.result != UnityWebRequest.Result.Success)
+                {
+                    // Try to parse the error response from the API
+                    try
+                    {
+                        var errorDto = JsonUtility.FromJson<ErrorResponseDto>(responseJson);
+                        if (!string.IsNullOrEmpty(errorDto?.error))
+                        {
+                            Debug.LogWarning($"[AuthManager] Auth error: {errorDto.error}");
+                            return TranslateApiError(errorDto.error);
+                        }
+                    }
+                    catch (System.Exception)
+                    {
+                        // Ignore parse errors, fall through to generic message
+                    }
+
+                    Debug.LogError($"[AuthManager] HTTP {request.responseCode}: {request.error}");
+                    return "Une erreur est survenue. Veuillez réessayer.";
+                }
+
+                // Success — parse the auth response
+                try
+                {
+                    var authResponse = JsonUtility.FromJson<AuthResponseDto>(responseJson);
+
+                    if (authResponse == null || string.IsNullOrEmpty(authResponse.token))
+                    {
+                        Debug.LogError("[AuthManager] Invalid auth response: missing token");
+                        return "Réponse invalide du serveur.";
+                    }
+
+                    _token = authResponse.token;
+                    _currentUser = authResponse.user;
+
+                    SaveTokenToPrefs();
+
+                    Debug.Log($"[AuthManager] Authenticated as {_currentUser?.username ?? "unknown"}");
+                    OnAuthStateChanged?.Invoke(true);
+
+                    return null; // Success
+                }
+                catch (System.Exception e)
+                {
+                    Debug.LogError($"[AuthManager] Error parsing auth response: {e.Message}");
+                    return "Réponse invalide du serveur.";
+                }
+            }
+        }
+
+        /// <summary>
+        /// Translates API error messages to user-friendly French messages.
+        /// </summary>
+        private string TranslateApiError(string apiError)
+        {
+            return apiError switch
+            {
+                "invalid email or password" => "Email ou mot de passe incorrect.",
+                "email already registered" => "Cette adresse email est déjà utilisée.",
+                "username already taken" => "Ce nom d'utilisateur est déjà pris.",
+                "email and password are required" => "L'email et le mot de passe sont requis.",
+                "internal server error" => "Erreur interne du serveur. Veuillez réessayer.",
+                _ => apiError
+            };
+        }
+
+        #endregion
+
+        #region Token Persistence
+
+        /// <summary>
+        /// Saves the current token and user data to PlayerPrefs.
+        /// </summary>
+        private void SaveTokenToPrefs()
+        {
+            PlayerPrefs.SetString(TOKEN_KEY, _token);
+
+            if (_currentUser != null)
+            {
+                string userJson = JsonUtility.ToJson(_currentUser);
+                PlayerPrefs.SetString(USER_JSON_KEY, userJson);
+            }
+
+            PlayerPrefs.Save();
+            Debug.Log("[AuthManager] Token saved to PlayerPrefs.");
+        }
+
+        /// <summary>
+        /// Loads the token and user data from PlayerPrefs on startup.
+        /// </summary>
+        private void LoadTokenFromPrefs()
+        {
+            _token = PlayerPrefs.GetString(TOKEN_KEY, null);
+
+            if (string.IsNullOrEmpty(_token))
+            {
+                _token = null;
+                Debug.Log("[AuthManager] No saved token found.");
+                return;
+            }
+
+            string userJson = PlayerPrefs.GetString(USER_JSON_KEY, null);
+
+            if (!string.IsNullOrEmpty(userJson))
+            {
+                try
+                {
+                    _currentUser = JsonUtility.FromJson<UserResponseDto>(userJson);
+                }
+                catch (System.Exception e)
+                {
+                    Debug.LogWarning($"[AuthManager] Error loading saved user: {e.Message}");
+                    _currentUser = null;
+                }
+            }
+
+            Debug.Log($"[AuthManager] Token loaded from PlayerPrefs (user: {_currentUser?.username ?? "unknown"}).");
+        }
+
+        #endregion
+    }
+}

--- a/Client/Assets/Scripts/Managers/BootManager.cs
+++ b/Client/Assets/Scripts/Managers/BootManager.cs
@@ -4,13 +4,14 @@ namespace Managers
 {
     /// <summary>
     /// Boot scene manager responsible for initializing all game managers
-    /// and transitioning to the main menu.
+    /// and transitioning to the appropriate scene based on authentication state.
     /// This should be the first scene loaded when the game starts.
     /// </summary>
     public class BootManager : MonoBehaviour
     {
         [Header("Scene Configuration")]
         [SerializeField] private string mainMenuSceneName = "MainMenu";
+        [SerializeField] private string loginSceneName = "Login";
 
         [Header("Optional: Splash Screen")]
         [SerializeField] private float splashDuration = 1f;
@@ -27,9 +28,9 @@ namespace Managers
             VerifyManagers();
 
             if (showSplash)
-                StartCoroutine(WaitAndLoadMainMenu());
+                StartCoroutine(WaitAndLoadNextScene());
             else
-                LoadMainMenu();
+                LoadNextScene();
         }
 
         private void VerifyManagers()
@@ -37,46 +38,65 @@ namespace Managers
             // Check GameManager
             if (GameManager.Instance != null)
             {
-                if (logInitialization) Debug.Log("[BootManager] ✓ GameManager ready");
+                if (logInitialization) Debug.Log("[BootManager] GameManager ready");
             }
             else
             {
-                Debug.LogError("[BootManager] ✗ GameManager not found!");
+                Debug.LogError("[BootManager] GameManager not found!");
             }
 
             // Check ExerciseManager
             if (ExerciseManager.Instance != null)
             {
-                if (logInitialization) Debug.Log("[BootManager] ✓ ExerciseManager ready");
+                if (logInitialization) Debug.Log("[BootManager] ExerciseManager ready");
             }
             else
             {
-                Debug.LogError("[BootManager] ✗ ExerciseManager not found!");
+                Debug.LogError("[BootManager] ExerciseManager not found!");
+            }
+
+            // Check AuthManager
+            if (AuthManager.Instance != null)
+            {
+                if (logInitialization) Debug.Log("[BootManager] AuthManager ready");
+            }
+            else
+            {
+                Debug.LogError("[BootManager] AuthManager not found!");
             }
         }
 
-        private System.Collections.IEnumerator WaitAndLoadMainMenu()
+        private System.Collections.IEnumerator WaitAndLoadNextScene()
         {
             if (logInitialization)
                 Debug.Log($"[BootManager] Showing splash for {splashDuration}s...");
 
             yield return new WaitForSeconds(splashDuration);
 
-            LoadMainMenu();
+            LoadNextScene();
         }
 
-        private void LoadMainMenu()
+        /// <summary>
+        /// Determines the next scene based on authentication state.
+        /// If the user has a saved token, goes straight to MainMenu.
+        /// Otherwise, shows the Login screen.
+        /// </summary>
+        private void LoadNextScene()
         {
+            bool isAuthenticated = AuthManager.Instance != null && AuthManager.Instance.TryAutoLogin();
+
+            string targetScene = isAuthenticated ? mainMenuSceneName : loginSceneName;
+
             if (logInitialization)
-                Debug.Log($"[BootManager] Loading {mainMenuSceneName}...");
+                Debug.Log($"[BootManager] Authenticated: {isAuthenticated}. Loading {targetScene}...");
 
             if (GameManager.Instance?.sceneManager != null)
             {
-                GameManager.Instance.sceneManager.LoadScene(mainMenuSceneName);
+                GameManager.Instance.sceneManager.LoadScene(targetScene);
             }
             else
             {
-                UnityEngine.SceneManagement.SceneManager.LoadScene(mainMenuSceneName);
+                UnityEngine.SceneManagement.SceneManager.LoadScene(targetScene);
             }
         }
     }

--- a/Client/Assets/Scripts/Managers/ExerciseManager.cs
+++ b/Client/Assets/Scripts/Managers/ExerciseManager.cs
@@ -143,11 +143,18 @@ namespace Managers
 
         /// <summary>
         /// Loads a level from a REST API endpoint.
+        /// Includes the JWT Bearer token if the user is authenticated.
         /// </summary>
         private async Task<LevelData> LoadLevelFromApiAsync(string apiUrl)
         {
             using (UnityWebRequest request = UnityWebRequest.Get(apiUrl))
             {
+                // Attach JWT token for authenticated requests
+                if (AuthManager.Instance != null && AuthManager.Instance.IsAuthenticated)
+                {
+                    request.SetRequestHeader("Authorization", $"Bearer {AuthManager.Instance.Token}");
+                }
+
                 var operation = request.SendWebRequest();
 
                 while (!operation.isDone)

--- a/Client/Assets/Scripts/Managers/GameManager.cs
+++ b/Client/Assets/Scripts/Managers/GameManager.cs
@@ -19,10 +19,12 @@ namespace Managers
         public UIManager uiManager;
         public AudioManager audioManager;
         public SceneManager sceneManager;
+        public AuthManager authManager;
 
         [Header("Scene Names")]
         [SerializeField] private string mainMenuSceneName = "MainMenu";
         [SerializeField] private string gameSceneName = "Game";
+        [SerializeField] private string loginSceneName = "Login";
 
         [Header("Audio Clips")]
         [SerializeField] private string correctSoundName = "Correct";
@@ -389,6 +391,25 @@ namespace Managers
             _explanationPopup = null;
 
             sceneManager?.LoadScene(mainMenuSceneName);
+        }
+
+        /// <summary>
+        /// Logs out the current user and navigates to the login scene.
+        /// </summary>
+        public void Logout()
+        {
+            Debug.Log("[GameManager] Logging out...");
+
+            if (authManager != null)
+            {
+                authManager.Logout();
+            }
+            else if (AuthManager.Instance != null)
+            {
+                AuthManager.Instance.Logout();
+            }
+
+            sceneManager?.LoadScene(loginSceneName);
         }
 
         /// <summary>

--- a/Client/Assets/Scripts/UI/LoginController.cs
+++ b/Client/Assets/Scripts/UI/LoginController.cs
@@ -1,0 +1,214 @@
+using Managers;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI
+{
+    /// <summary>
+    /// Controls the login screen UI.
+    /// Handles email/password input, login button, error display,
+    /// and navigation to the register panel.
+    /// </summary>
+    public class LoginController : MonoBehaviour
+    {
+        [Header("Input Fields")]
+        [SerializeField] private TMP_InputField emailInput;
+        [SerializeField] private TMP_InputField passwordInput;
+
+        [Header("Buttons")]
+        [SerializeField] private Button loginButton;
+        [SerializeField] private Button goToRegisterButton;
+
+        [Header("Feedback")]
+        [SerializeField] private TextMeshProUGUI errorText;
+
+        [Header("Panel References")]
+        [SerializeField] private GameObject loginPanel;
+        [SerializeField] private GameObject registerPanel;
+
+        private bool _isLoading;
+
+        private void Awake()
+        {
+            if (loginButton != null)
+            {
+                loginButton.onClick.AddListener(OnLoginClick);
+            }
+
+            if (goToRegisterButton != null)
+            {
+                goToRegisterButton.onClick.AddListener(OnGoToRegisterClick);
+            }
+        }
+
+        private void OnEnable()
+        {
+            ClearError();
+            ClearInputs();
+        }
+
+        /// <summary>
+        /// Handles the login button click.
+        /// Validates input, calls AuthManager, and navigates on success.
+        /// </summary>
+        private async void OnLoginClick()
+        {
+            if (_isLoading)
+            {
+                return;
+            }
+
+            ClearError();
+
+            string email = emailInput?.text?.Trim();
+            string password = passwordInput?.text;
+
+            // Client-side validation
+            if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
+            {
+                ShowError("Veuillez remplir tous les champs.");
+                return;
+            }
+
+            if (!email.Contains("@"))
+            {
+                ShowError("Veuillez entrer une adresse email valide.");
+                return;
+            }
+
+            SetLoading(true);
+
+            string error = await AuthManager.Instance.LoginAsync(email, password);
+
+            SetLoading(false);
+
+            if (error != null)
+            {
+                ShowError(error);
+                return;
+            }
+
+            Debug.Log("[LoginController] Login successful, navigating to main menu.");
+            NavigateToMainMenu();
+        }
+
+        /// <summary>
+        /// Switches to the register panel.
+        /// </summary>
+        private void OnGoToRegisterClick()
+        {
+            if (loginPanel != null)
+            {
+                loginPanel.SetActive(false);
+            }
+
+            if (registerPanel != null)
+            {
+                registerPanel.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Navigates to the main menu scene after successful authentication.
+        /// </summary>
+        private void NavigateToMainMenu()
+        {
+            if (GameManager.Instance?.sceneManager != null)
+            {
+                GameManager.Instance.sceneManager.LoadScene("MainMenu");
+            }
+            else
+            {
+                UnityEngine.SceneManagement.SceneManager.LoadScene("MainMenu");
+            }
+        }
+
+        /// <summary>
+        /// Shows an error message to the user.
+        /// </summary>
+        /// <param name="message">The error message to display.</param>
+        private void ShowError(string message)
+        {
+            if (errorText != null)
+            {
+                errorText.text = message;
+                errorText.gameObject.SetActive(true);
+            }
+
+            Debug.LogWarning($"[LoginController] {message}");
+        }
+
+        /// <summary>
+        /// Clears the error message.
+        /// </summary>
+        private void ClearError()
+        {
+            if (errorText != null)
+            {
+                errorText.text = "";
+                errorText.gameObject.SetActive(false);
+            }
+        }
+
+        /// <summary>
+        /// Clears the input fields.
+        /// </summary>
+        private void ClearInputs()
+        {
+            if (emailInput != null)
+            {
+                emailInput.text = "";
+            }
+
+            if (passwordInput != null)
+            {
+                passwordInput.text = "";
+            }
+        }
+
+        /// <summary>
+        /// Sets the loading state. Disables interactions while loading.
+        /// </summary>
+        /// <param name="loading">Whether the login request is in progress.</param>
+        private void SetLoading(bool loading)
+        {
+            _isLoading = loading;
+
+            if (loginButton != null)
+            {
+                loginButton.interactable = !loading;
+            }
+
+            if (emailInput != null)
+            {
+                emailInput.interactable = !loading;
+            }
+
+            if (passwordInput != null)
+            {
+                passwordInput.interactable = !loading;
+            }
+
+            // Update button text to show loading state
+            var buttonText = loginButton?.GetComponentInChildren<TextMeshProUGUI>();
+            if (buttonText != null)
+            {
+                buttonText.text = loading ? "Connexion..." : "Se connecter";
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (loginButton != null)
+            {
+                loginButton.onClick.RemoveListener(OnLoginClick);
+            }
+
+            if (goToRegisterButton != null)
+            {
+                goToRegisterButton.onClick.RemoveListener(OnGoToRegisterClick);
+            }
+        }
+    }
+}

--- a/Client/Assets/Scripts/UI/RegisterController.cs
+++ b/Client/Assets/Scripts/UI/RegisterController.cs
@@ -1,0 +1,241 @@
+using Managers;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UI
+{
+    /// <summary>
+    /// Controls the register screen UI.
+    /// Handles username/email/password input, registration button, error display,
+    /// client-side validation, and navigation back to the login panel.
+    /// </summary>
+    public class RegisterController : MonoBehaviour
+    {
+        [Header("Input Fields")]
+        [SerializeField] private TMP_InputField usernameInput;
+        [SerializeField] private TMP_InputField emailInput;
+        [SerializeField] private TMP_InputField passwordInput;
+
+        [Header("Buttons")]
+        [SerializeField] private Button registerButton;
+        [SerializeField] private Button goToLoginButton;
+
+        [Header("Feedback")]
+        [SerializeField] private TextMeshProUGUI errorText;
+
+        [Header("Panel References")]
+        [SerializeField] private GameObject loginPanel;
+        [SerializeField] private GameObject registerPanel;
+
+        private const int MIN_USERNAME_LENGTH = 3;
+        private const int MIN_PASSWORD_LENGTH = 8;
+
+        private bool _isLoading;
+
+        private void Awake()
+        {
+            if (registerButton != null)
+            {
+                registerButton.onClick.AddListener(OnRegisterClick);
+            }
+
+            if (goToLoginButton != null)
+            {
+                goToLoginButton.onClick.AddListener(OnGoToLoginClick);
+            }
+        }
+
+        private void OnEnable()
+        {
+            ClearError();
+            ClearInputs();
+        }
+
+        /// <summary>
+        /// Handles the register button click.
+        /// Validates input, calls AuthManager, and navigates on success.
+        /// </summary>
+        private async void OnRegisterClick()
+        {
+            if (_isLoading)
+            {
+                return;
+            }
+
+            ClearError();
+
+            string username = usernameInput?.text?.Trim();
+            string email = emailInput?.text?.Trim();
+            string password = passwordInput?.text;
+
+            // Client-side validation (mirrors server rules)
+            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(email) || string.IsNullOrEmpty(password))
+            {
+                ShowError("Veuillez remplir tous les champs.");
+                return;
+            }
+
+            if (username.Length < MIN_USERNAME_LENGTH)
+            {
+                ShowError($"Le nom d'utilisateur doit contenir au moins {MIN_USERNAME_LENGTH} caractères.");
+                return;
+            }
+
+            if (!email.Contains("@"))
+            {
+                ShowError("Veuillez entrer une adresse email valide.");
+                return;
+            }
+
+            if (password.Length < MIN_PASSWORD_LENGTH)
+            {
+                ShowError($"Le mot de passe doit contenir au moins {MIN_PASSWORD_LENGTH} caractères.");
+                return;
+            }
+
+            SetLoading(true);
+
+            string error = await AuthManager.Instance.RegisterAsync(email, username, password);
+
+            SetLoading(false);
+
+            if (error != null)
+            {
+                ShowError(error);
+                return;
+            }
+
+            Debug.Log("[RegisterController] Registration successful, navigating to main menu.");
+            NavigateToMainMenu();
+        }
+
+        /// <summary>
+        /// Switches back to the login panel.
+        /// </summary>
+        private void OnGoToLoginClick()
+        {
+            if (registerPanel != null)
+            {
+                registerPanel.SetActive(false);
+            }
+
+            if (loginPanel != null)
+            {
+                loginPanel.SetActive(true);
+            }
+        }
+
+        /// <summary>
+        /// Navigates to the main menu scene after successful authentication.
+        /// </summary>
+        private void NavigateToMainMenu()
+        {
+            if (GameManager.Instance?.sceneManager != null)
+            {
+                GameManager.Instance.sceneManager.LoadScene("MainMenu");
+            }
+            else
+            {
+                UnityEngine.SceneManagement.SceneManager.LoadScene("MainMenu");
+            }
+        }
+
+        /// <summary>
+        /// Shows an error message to the user.
+        /// </summary>
+        /// <param name="message">The error message to display.</param>
+        private void ShowError(string message)
+        {
+            if (errorText != null)
+            {
+                errorText.text = message;
+                errorText.gameObject.SetActive(true);
+            }
+
+            Debug.LogWarning($"[RegisterController] {message}");
+        }
+
+        /// <summary>
+        /// Clears the error message.
+        /// </summary>
+        private void ClearError()
+        {
+            if (errorText != null)
+            {
+                errorText.text = "";
+                errorText.gameObject.SetActive(false);
+            }
+        }
+
+        /// <summary>
+        /// Clears the input fields.
+        /// </summary>
+        private void ClearInputs()
+        {
+            if (usernameInput != null)
+            {
+                usernameInput.text = "";
+            }
+
+            if (emailInput != null)
+            {
+                emailInput.text = "";
+            }
+
+            if (passwordInput != null)
+            {
+                passwordInput.text = "";
+            }
+        }
+
+        /// <summary>
+        /// Sets the loading state. Disables interactions while loading.
+        /// </summary>
+        /// <param name="loading">Whether the register request is in progress.</param>
+        private void SetLoading(bool loading)
+        {
+            _isLoading = loading;
+
+            if (registerButton != null)
+            {
+                registerButton.interactable = !loading;
+            }
+
+            if (usernameInput != null)
+            {
+                usernameInput.interactable = !loading;
+            }
+
+            if (emailInput != null)
+            {
+                emailInput.interactable = !loading;
+            }
+
+            if (passwordInput != null)
+            {
+                passwordInput.interactable = !loading;
+            }
+
+            // Update button text to show loading state
+            var buttonText = registerButton?.GetComponentInChildren<TextMeshProUGUI>();
+            if (buttonText != null)
+            {
+                buttonText.text = loading ? "Inscription..." : "S'inscrire";
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (registerButton != null)
+            {
+                registerButton.onClick.RemoveListener(OnRegisterClick);
+            }
+
+            if (goToLoginButton != null)
+            {
+                goToLoginButton.onClick.RemoveListener(OnGoToLoginClick);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **New**: `AuthManager.cs` — Singleton managing login, register, logout, auto-login with JWT token persistence in PlayerPrefs
- **New**: `AuthDtos.cs` — Serializable DTOs for auth API requests/responses (`LoginRequestDto`, `RegisterRequestDto`, `AuthResponseDto`, `UserResponseDto`, `ErrorResponseDto`)
- **New**: `LoginController.cs` — Login screen UI controller with email/password input, client-side validation, loading state, and French error messages
- **New**: `RegisterController.cs` — Register screen UI controller with username/email/password input, validation (username >= 3 chars, password >= 8 chars), and panel toggling
- **Modified**: `GameManager.cs` — Added `authManager` reference, `loginSceneName` field, and `Logout()` method
- **Modified**: `BootManager.cs` — Auth-aware routing: checks `AuthManager.TryAutoLogin()` to decide between Login or MainMenu scene
- **Modified**: `ExerciseManager.cs` — Adds `Authorization: Bearer <token>` header to API calls when authenticated

## Flow

```
Boot.unity
  └─ BootManager.Start()
      ├─ Token exists? ──YES──▶ MainMenu.unity
      └─ NO ──▶ Login.unity
                  ├─ Login panel (default)
                  │   └─ Login → AuthManager.LoginAsync() → MainMenu
                  └─ Register panel (toggle)
                      └─ Register → AuthManager.RegisterAsync() → MainMenu
```

## Unity Editor setup required

A new `Login.unity` scene needs to be created with Canvas UI (input fields, buttons, error text). Detailed setup tutorial available locally in `temp/tuto-login-register.md`.

Closes ME-10