### PR TITLE
feat(client): add gamification system — XP, EcoCoins, daily streak (ME-23)

### DIFF
--- a/Client/Assets/Scenes/Boot.unity
+++ b/Client/Assets/Scenes/Boot.unity
@@ -344,6 +344,7 @@ MonoBehaviour:
   audioManager: {fileID: 708438290}
   sceneManager: {fileID: 708438291}
   authManager: {fileID: 1180491728}
+  gamificationManager: {fileID: 1537526519}
   mainMenuSceneName: MainMenu
   gameSceneName: Game
   loginSceneName: Login
@@ -393,6 +394,50 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 458.02933, y: 1011.253, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1537526518
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1537526520}
+  - component: {fileID: 1537526519}
+  m_Layer: 0
+  m_Name: GamificationManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1537526519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1537526518}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cffba2fb566d14dbfab1e4a101fa7872, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Managers.GamificationManager
+--- !u!4 &1537526520
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1537526518}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 540, y: 960, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -455,3 +500,4 @@ SceneRoots:
   - {fileID: 708438288}
   - {fileID: 1845528677}
   - {fileID: 1180491729}
+  - {fileID: 1537526520}

--- a/Client/Assets/Scenes/Game.unity
+++ b/Client/Assets/Scenes/Game.unity
@@ -151,6 +151,9 @@ RectTransform:
   m_Children:
   - {fileID: 1474692040}
   - {fileID: 368859562}
+  - {fileID: 898202999}
+  - {fileID: 1189326433}
+  - {fileID: 157465213}
   m_Father: {fileID: 152321074}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -461,6 +464,42 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &157465212
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 157465213}
+  m_Layer: 5
+  m_Name: LevelUpBadge
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &157465213
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 157465212}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1703274341}
+  m_Father: {fileID: 30958046}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &368859561
 GameObject:
   m_ObjectHideFlags: 0
@@ -625,6 +664,10 @@ MonoBehaviour:
   victoryNextLevelButton: {fileID: 0}
   victoryMenuButton: {fileID: 0}
   victoryStars: []
+  victoryXPText: {fileID: 898203000}
+  victoryCoinsText: {fileID: 1189326434}
+  victoryLevelUpBadge: {fileID: 157465212}
+  victoryLevelUpText: {fileID: 1703274342}
   quizPanel: {fileID: 0}
 --- !u!4 &369713524
 Transform:
@@ -1767,6 +1810,143 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &898202998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 898202999}
+  - component: {fileID: 898203001}
+  - component: {fileID: 898203000}
+  m_Layer: 5
+  m_Name: VictoryXPText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &898202999
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898202998}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 30958046}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 36}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &898203000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898202998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: +0XP
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &898203001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 898202998}
+  m_CullTransparentMesh: 1
 --- !u!1 &928537523
 GameObject:
   m_ObjectHideFlags: 0
@@ -2196,6 +2376,143 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1177623576}
+  m_CullTransparentMesh: 1
+--- !u!1 &1189326432
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1189326433}
+  - component: {fileID: 1189326435}
+  - component: {fileID: 1189326434}
+  m_Layer: 5
+  m_Name: VictoryCoinsText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1189326433
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1189326432}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 30958046}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1189326434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1189326432}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: +0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1189326435
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1189326432}
   m_CullTransparentMesh: 1
 --- !u!1 &1207510771
 GameObject:
@@ -3436,6 +3753,143 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1676594425}
+  m_CullTransparentMesh: 1
+--- !u!1 &1703274340
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1703274341}
+  - component: {fileID: 1703274343}
+  - component: {fileID: 1703274342}
+  m_Layer: 5
+  m_Name: LevelUpText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1703274341
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703274340}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 157465213}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1703274342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703274340}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Niveau 2 !
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1703274343
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1703274340}
   m_CullTransparentMesh: 1
 --- !u!1 &1784533706
 GameObject:

--- a/Client/Assets/Scenes/MainMenu.unity
+++ b/Client/Assets/Scenes/MainMenu.unity
@@ -119,6 +119,143 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &106829841
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 106829842}
+  - component: {fileID: 106829844}
+  - component: {fileID: 106829843}
+  m_Layer: 5
+  m_Name: PlayerLevelText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &106829842
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106829841}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 310575869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 238}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &106829843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106829841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Nv. 1
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &106829844
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 106829841}
+  m_CullTransparentMesh: 1
 --- !u!1 &300287723
 GameObject:
   m_ObjectHideFlags: 0
@@ -351,6 +488,11 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1323158717}
+  - {fileID: 106829842}
+  - {fileID: 1685874287}
+  - {fileID: 1541682357}
+  - {fileID: 1458813232}
+  - {fileID: 1769829358}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -358,6 +500,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &516403350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 516403351}
+  - component: {fileID: 516403353}
+  - component: {fileID: 516403352}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &516403351
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516403350}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1685874287}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &516403352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516403350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &516403353
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 516403350}
+  m_CullTransparentMesh: 1
 --- !u!1 &1265618324
 GameObject:
   m_ObjectHideFlags: 0
@@ -392,6 +609,11 @@ MonoBehaviour:
   quitButton: {fileID: 0}
   startingLevel: 1
   autoSelectHighestLevel: 0
+  playerLevelText: {fileID: 106829843}
+  xpProgressBar: {fileID: 1685874288}
+  xpProgressText: {fileID: 1541682358}
+  coinCountText: {fileID: 1458813233}
+  streakText: {fileID: 1769829359}
 --- !u!4 &1265618326
 Transform:
   m_ObjectHideFlags: 0
@@ -528,6 +750,391 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 300, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1429623262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1429623263}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1429623263
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1429623262}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1473688275}
+  m_Father: {fileID: 1685874287}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -5, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1458813231
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1458813232}
+  - component: {fileID: 1458813234}
+  - component: {fileID: 1458813233}
+  m_Layer: 5
+  m_Name: CoinCountText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1458813232
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458813231}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 310575869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 576}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1458813233
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458813231}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1458813234
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1458813231}
+  m_CullTransparentMesh: 1
+--- !u!1 &1473688274
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1473688275}
+  - component: {fileID: 1473688277}
+  - component: {fileID: 1473688276}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1473688275
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473688274}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1429623263}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1473688276
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473688274}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1473688277
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1473688274}
+  m_CullTransparentMesh: 1
+--- !u!1 &1541682356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1541682357}
+  - component: {fileID: 1541682359}
+  - component: {fileID: 1541682358}
+  m_Layer: 5
+  m_Name: XPProgressText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1541682357
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541682356}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 310575869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 362}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1541682358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541682356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0 / 100 XP
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1541682359
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541682356}
+  m_CullTransparentMesh: 1
 --- !u!1 &1547573580
 GameObject:
   m_ObjectHideFlags: 0
@@ -571,6 +1178,10 @@ MonoBehaviour:
   victoryNextLevelButton: {fileID: 0}
   victoryMenuButton: {fileID: 0}
   victoryStars: []
+  victoryXPText: {fileID: 0}
+  victoryCoinsText: {fileID: 0}
+  victoryLevelUpBadge: {fileID: 0}
+  victoryLevelUpText: {fileID: 0}
   quizPanel: {fileID: 0}
 --- !u!4 &1547573582
 Transform:
@@ -587,6 +1198,232 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1685874286
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1685874287}
+  - component: {fileID: 1685874288}
+  m_Layer: 5
+  m_Name: XPProgressBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1685874287
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685874286}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 516403351}
+  - {fileID: 1429623263}
+  m_Father: {fileID: 310575869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 313}
+  m_SizeDelta: {x: 160, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1685874288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685874286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Slider
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0.42114633, g: 0.9811321, b: 0.65749395, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 1473688275}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &1769829357
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1769829358}
+  - component: {fileID: 1769829360}
+  - component: {fileID: 1769829359}
+  m_Layer: 5
+  m_Name: StreakText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1769829358
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769829357}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 310575869}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 718}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1769829359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769829357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0 jour
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1769829360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1769829357}
+  m_CullTransparentMesh: 1
 --- !u!1 &1826643755
 GameObject:
   m_ObjectHideFlags: 0

--- a/Client/Assets/Scripts/Managers/BootManager.cs
+++ b/Client/Assets/Scripts/Managers/BootManager.cs
@@ -64,6 +64,16 @@ namespace Managers
             {
                 Debug.LogError("[BootManager] AuthManager not found!");
             }
+
+            // Check GamificationManager
+            if (GamificationManager.Instance != null)
+            {
+                if (logInitialization) Debug.Log("[BootManager] GamificationManager ready");
+            }
+            else
+            {
+                Debug.LogError("[BootManager] GamificationManager not found!");
+            }
         }
 
         private System.Collections.IEnumerator WaitAndLoadNextScene()

--- a/Client/Assets/Scripts/Managers/GameManager.cs
+++ b/Client/Assets/Scripts/Managers/GameManager.cs
@@ -20,6 +20,7 @@ namespace Managers
         public AudioManager audioManager;
         public SceneManager sceneManager;
         public AuthManager authManager;
+        public GamificationManager gamificationManager;
 
         [Header("Scene Names")]
         [SerializeField] private string mainMenuSceneName = "MainMenu";
@@ -220,6 +221,12 @@ namespace Managers
                 audioManager.PlaySound(isCorrect ? correctSoundName : incorrectSoundName);
             }
 
+            // Award XP for correct answers
+            if (isCorrect)
+            {
+                gamificationManager?.AwardCorrectAnswerXP();
+            }
+
             // Show visual feedback on the exercise panel (correct/incorrect highlighting)
             _exerciseUIController?.ShowFeedback(isCorrect);
 
@@ -322,6 +329,7 @@ namespace Managers
 
         /// <summary>
         /// Handles level victory.
+        /// Awards gamification rewards and persists star rating.
         /// </summary>
         private void WinLevel()
         {
@@ -347,6 +355,16 @@ namespace Managers
             int score = _currentLives * 100;
             int starsEarned = CalculateStars(_currentLives, maxLives);
 
+            // Persist star rating (only saves if better than previous)
+            LevelScoreManager.SaveLevelStars(_currentLevelId, starsEarned);
+
+            // Award gamification rewards
+            LevelRewards rewards = default;
+            if (gamificationManager != null)
+            {
+                rewards = gamificationManager.AwardLevelCompletion(_currentLives, maxLives);
+            }
+
             if (audioManager != null)
             {
                 audioManager.PlaySound(victorySoundName);
@@ -354,7 +372,7 @@ namespace Managers
 
             if (uiManager != null)
             {
-                uiManager.ShowVictoryScreen(score, starsEarned, hasNextLevel);
+                uiManager.ShowVictoryScreen(score, starsEarned, hasNextLevel, rewards);
             }
         }
 
@@ -464,12 +482,15 @@ namespace Managers
         }
 
         /// <summary>
-        /// Resets all saved progress.
+        /// Resets all saved progress, including gamification data.
         /// </summary>
         public void ResetProgress()
         {
             PlayerPrefs.DeleteKey(HIGHEST_LEVEL_KEY);
             PlayerPrefs.Save();
+
+            gamificationManager?.ResetAll();
+
             Debug.Log("[GameManager] Progress reset!");
         }
 

--- a/Client/Assets/Scripts/Managers/GamificationManager.cs
+++ b/Client/Assets/Scripts/Managers/GamificationManager.cs
@@ -1,0 +1,440 @@
+using System;
+using UnityEngine;
+
+namespace Managers
+{
+    /// <summary>
+    /// Central manager for all gamification systems: XP, EcoCoins, daily streak.
+    /// Persists data via PlayerPrefs and raises events for UI updates.
+    /// Implements the Singleton pattern and persists across scene loads.
+    /// </summary>
+    public class GamificationManager : MonoBehaviour
+    {
+        public static GamificationManager Instance { get; private set; }
+
+        #region Constants — XP Rewards
+
+        /// <summary>XP awarded for each correct answer.</summary>
+        private const int XP_PER_CORRECT_ANSWER = 10;
+
+        /// <summary>Bonus XP awarded for completing a level.</summary>
+        private const int XP_LEVEL_COMPLETION_BONUS = 50;
+
+        /// <summary>Bonus XP awarded for a perfect level (no lives lost).</summary>
+        private const int XP_PERFECT_BONUS = 30;
+
+        /// <summary>Amount of XP required per player level.</summary>
+        private const int XP_PER_LEVEL = 100;
+
+        #endregion
+
+        #region Constants — EcoCoin Rewards
+
+        /// <summary>EcoCoins awarded for completing a level.</summary>
+        private const int COINS_PER_LEVEL = 5;
+
+        /// <summary>Bonus EcoCoins for a perfect level (no lives lost).</summary>
+        private const int COINS_PERFECT_BONUS = 10;
+
+        /// <summary>EcoCoins awarded per consecutive streak day.</summary>
+        private const int COINS_PER_STREAK_DAY = 2;
+
+        #endregion
+
+        #region Constants — PlayerPrefs Keys
+
+        private const string KEY_TOTAL_XP = "Gamification_TotalXP";
+        private const string KEY_ECO_COINS = "Gamification_EcoCoins";
+        private const string KEY_STREAK = "Gamification_Streak";
+        private const string KEY_LAST_PLAY_DATE = "Gamification_LastPlayDate";
+
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Raised when XP is gained. Parameter is the amount gained.
+        /// </summary>
+        public event Action<int> OnXPGained;
+
+        /// <summary>
+        /// Raised when the player levels up. Parameter is the new player level.
+        /// </summary>
+        public event Action<int> OnLevelUp;
+
+        /// <summary>
+        /// Raised when EcoCoins are earned. Parameter is the amount earned.
+        /// </summary>
+        public event Action<int> OnCoinsEarned;
+
+        /// <summary>
+        /// Raised when the daily streak is updated. Parameter is the new streak count.
+        /// </summary>
+        public event Action<int> OnStreakUpdated;
+
+        #endregion
+
+        #region State
+
+        private int _totalXP;
+        private int _ecoCoins;
+        private int _streak;
+        private string _lastPlayDate;
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>Total accumulated XP across all play sessions.</summary>
+        public int TotalXP => _totalXP;
+
+        /// <summary>Current player level, derived from total XP.</summary>
+        public int PlayerLevel => 1 + _totalXP / XP_PER_LEVEL;
+
+        /// <summary>XP progress within the current level (0 to XP_PER_LEVEL - 1).</summary>
+        public int XPInCurrentLevel => _totalXP % XP_PER_LEVEL;
+
+        /// <summary>XP required to complete the current level.</summary>
+        public int XPRequiredForLevel => XP_PER_LEVEL;
+
+        /// <summary>Current EcoCoin balance.</summary>
+        public int EcoCoins => _ecoCoins;
+
+        /// <summary>Current consecutive daily play streak.</summary>
+        public int Streak => _streak;
+
+        /// <summary>
+        /// Multiplier applied to XP gains based on streak.
+        /// 1.0x base + 0.1x per streak day, capped at 2.0x.
+        /// </summary>
+        public float StreakMultiplier => Mathf.Min(1f + _streak * 0.1f, 2f);
+
+        #endregion
+
+        #region Singleton Setup
+
+        private void Awake()
+        {
+            if (Instance == null)
+            {
+                Instance = this;
+
+                if (transform.parent != null)
+                {
+                    transform.SetParent(null);
+                    Debug.LogWarning("[GamificationManager] Was not at root level. Moved automatically.");
+                }
+
+                DontDestroyOnLoad(gameObject);
+
+                LoadFromPrefs();
+                CheckDailyStreak();
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        #endregion
+
+        #region Public API — XP
+
+        /// <summary>
+        /// Awards XP for a correct answer, applying the streak multiplier.
+        /// </summary>
+        public void AwardCorrectAnswerXP()
+        {
+            int baseXP = XP_PER_CORRECT_ANSWER;
+            int xpGained = Mathf.RoundToInt(baseXP * StreakMultiplier);
+
+            AddXP(xpGained);
+
+            Debug.Log($"[GamificationManager] Correct answer: +{xpGained} XP (x{StreakMultiplier:F1} streak)");
+        }
+
+        /// <summary>
+        /// Awards XP and EcoCoins for completing a level.
+        /// Call this from GameManager.WinLevel().
+        /// </summary>
+        /// <param name="remainingLives">Lives remaining at level end.</param>
+        /// <param name="maxLives">Maximum lives the player started with.</param>
+        /// <returns>A LevelRewards struct with the breakdown of all rewards earned.</returns>
+        public LevelRewards AwardLevelCompletion(int remainingLives, int maxLives)
+        {
+            bool isPerfect = remainingLives >= maxLives;
+            int previousLevel = PlayerLevel;
+
+            // XP calculation
+            int baseXP = XP_LEVEL_COMPLETION_BONUS;
+            int perfectXP = isPerfect ? XP_PERFECT_BONUS : 0;
+            int totalBaseXP = baseXP + perfectXP;
+            int totalXP = Mathf.RoundToInt(totalBaseXP * StreakMultiplier);
+
+            // Coin calculation
+            int baseCoins = COINS_PER_LEVEL;
+            int perfectCoins = isPerfect ? COINS_PERFECT_BONUS : 0;
+            int streakCoins = _streak > 0 ? COINS_PER_STREAK_DAY * _streak : 0;
+            int totalCoins = baseCoins + perfectCoins + streakCoins;
+
+            // Apply rewards
+            AddXP(totalXP);
+            AddCoins(totalCoins);
+
+            // Update streak date (player played today)
+            UpdateLastPlayDate();
+
+            bool didLevelUp = PlayerLevel > previousLevel;
+
+            var rewards = new LevelRewards
+            {
+                xpEarned = totalXP,
+                coinsEarned = totalCoins,
+                isPerfect = isPerfect,
+                didLevelUp = didLevelUp,
+                newPlayerLevel = PlayerLevel
+            };
+
+            Debug.Log($"[GamificationManager] Level complete: +{totalXP} XP, +{totalCoins} coins" +
+                      $"{(isPerfect ? " (PERFECT)" : "")}{(didLevelUp ? $" LEVEL UP -> {PlayerLevel}" : "")}");
+
+            return rewards;
+        }
+
+        #endregion
+
+        #region Public API — EcoCoins
+
+        /// <summary>
+        /// Spends EcoCoins if the player has enough.
+        /// </summary>
+        /// <param name="amount">Number of coins to spend.</param>
+        /// <returns>True if the purchase succeeded, false if insufficient funds.</returns>
+        public bool SpendCoins(int amount)
+        {
+            if (amount <= 0)
+            {
+                Debug.LogWarning("[GamificationManager] SpendCoins called with non-positive amount.");
+                return false;
+            }
+
+            if (_ecoCoins < amount)
+            {
+                Debug.Log($"[GamificationManager] Not enough coins: have {_ecoCoins}, need {amount}");
+                return false;
+            }
+
+            _ecoCoins -= amount;
+            SaveToPrefs();
+
+            Debug.Log($"[GamificationManager] Spent {amount} coins. Balance: {_ecoCoins}");
+            return true;
+        }
+
+        #endregion
+
+        #region Public API — Streak
+
+        /// <summary>
+        /// Gets a formatted display string for the streak (e.g. "5 jours").
+        /// </summary>
+        public string GetStreakDisplayText()
+        {
+            if (_streak <= 0) return "0 jour";
+            return _streak == 1 ? "1 jour" : $"{_streak} jours";
+        }
+
+        #endregion
+
+        #region Public API — Reset
+
+        /// <summary>
+        /// Resets all gamification data. Used when resetting progress.
+        /// </summary>
+        public void ResetAll()
+        {
+            _totalXP = 0;
+            _ecoCoins = 0;
+            _streak = 0;
+            _lastPlayDate = "";
+
+            PlayerPrefs.DeleteKey(KEY_TOTAL_XP);
+            PlayerPrefs.DeleteKey(KEY_ECO_COINS);
+            PlayerPrefs.DeleteKey(KEY_STREAK);
+            PlayerPrefs.DeleteKey(KEY_LAST_PLAY_DATE);
+            PlayerPrefs.Save();
+
+            Debug.Log("[GamificationManager] All gamification data reset.");
+        }
+
+        #endregion
+
+        #region Internal — XP & Coins Helpers
+
+        /// <summary>
+        /// Adds XP, checks for level-up, and saves.
+        /// </summary>
+        private void AddXP(int amount)
+        {
+            int previousLevel = PlayerLevel;
+
+            _totalXP += amount;
+            SaveToPrefs();
+
+            OnXPGained?.Invoke(amount);
+
+            if (PlayerLevel > previousLevel)
+            {
+                OnLevelUp?.Invoke(PlayerLevel);
+                Debug.Log($"[GamificationManager] Level up! Now level {PlayerLevel}");
+            }
+        }
+
+        /// <summary>
+        /// Adds EcoCoins and saves.
+        /// </summary>
+        private void AddCoins(int amount)
+        {
+            _ecoCoins += amount;
+            SaveToPrefs();
+
+            OnCoinsEarned?.Invoke(amount);
+        }
+
+        #endregion
+
+        #region Internal — Daily Streak
+
+        /// <summary>
+        /// Checks the daily streak on startup.
+        /// If the player played yesterday, increments the streak.
+        /// If they played today, keeps the streak.
+        /// Otherwise, resets to 0.
+        /// </summary>
+        private void CheckDailyStreak()
+        {
+            if (string.IsNullOrEmpty(_lastPlayDate))
+            {
+                Debug.Log("[GamificationManager] No previous play date. Streak starts at 0.");
+                return;
+            }
+
+            string today = DateTime.Now.ToString("yyyy-MM-dd");
+            string yesterday = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+
+            if (_lastPlayDate == today)
+            {
+                // Already played today, keep streak as-is
+                Debug.Log($"[GamificationManager] Already played today. Streak: {_streak}");
+            }
+            else if (_lastPlayDate == yesterday)
+            {
+                // Played yesterday — increment streak
+                _streak++;
+                _lastPlayDate = today;
+                SaveToPrefs();
+
+                Debug.Log($"[GamificationManager] Streak continued! Day {_streak}");
+                OnStreakUpdated?.Invoke(_streak);
+            }
+            else
+            {
+                // Missed a day — reset streak
+                int oldStreak = _streak;
+                _streak = 0;
+                SaveToPrefs();
+
+                Debug.Log($"[GamificationManager] Streak broken (last play: {_lastPlayDate}). Reset from {oldStreak} to 0.");
+                OnStreakUpdated?.Invoke(_streak);
+            }
+        }
+
+        /// <summary>
+        /// Updates the last play date to today. Called when the player completes a level.
+        /// </summary>
+        private void UpdateLastPlayDate()
+        {
+            string today = DateTime.Now.ToString("yyyy-MM-dd");
+
+            if (_lastPlayDate != today)
+            {
+                // First completion today — if we haven't already incremented in CheckDailyStreak
+                if (string.IsNullOrEmpty(_lastPlayDate))
+                {
+                    _streak = 1;
+                }
+                else
+                {
+                    string yesterday = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd");
+                    if (_lastPlayDate != yesterday)
+                    {
+                        // Gap in play — streak was already reset by CheckDailyStreak,
+                        // but start a new streak of 1
+                        _streak = 1;
+                    }
+                    // If lastPlayDate == yesterday, streak was already incremented in CheckDailyStreak
+                }
+
+                _lastPlayDate = today;
+                SaveToPrefs();
+
+                OnStreakUpdated?.Invoke(_streak);
+                Debug.Log($"[GamificationManager] Play date updated to {today}. Streak: {_streak}");
+            }
+        }
+
+        #endregion
+
+        #region Persistence
+
+        /// <summary>
+        /// Loads all gamification data from PlayerPrefs.
+        /// </summary>
+        private void LoadFromPrefs()
+        {
+            _totalXP = PlayerPrefs.GetInt(KEY_TOTAL_XP, 0);
+            _ecoCoins = PlayerPrefs.GetInt(KEY_ECO_COINS, 0);
+            _streak = PlayerPrefs.GetInt(KEY_STREAK, 0);
+            _lastPlayDate = PlayerPrefs.GetString(KEY_LAST_PLAY_DATE, "");
+
+            Debug.Log($"[GamificationManager] Loaded — XP: {_totalXP}, Level: {PlayerLevel}, " +
+                      $"Coins: {_ecoCoins}, Streak: {_streak}, Last play: {_lastPlayDate}");
+        }
+
+        /// <summary>
+        /// Saves all gamification data to PlayerPrefs.
+        /// </summary>
+        private void SaveToPrefs()
+        {
+            PlayerPrefs.SetInt(KEY_TOTAL_XP, _totalXP);
+            PlayerPrefs.SetInt(KEY_ECO_COINS, _ecoCoins);
+            PlayerPrefs.SetInt(KEY_STREAK, _streak);
+            PlayerPrefs.SetString(KEY_LAST_PLAY_DATE, _lastPlayDate);
+            PlayerPrefs.Save();
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Data struct returned by AwardLevelCompletion with the full reward breakdown.
+    /// </summary>
+    [System.Serializable]
+    public struct LevelRewards
+    {
+        /// <summary>Total XP earned from this level completion.</summary>
+        public int xpEarned;
+
+        /// <summary>Total EcoCoins earned from this level completion.</summary>
+        public int coinsEarned;
+
+        /// <summary>Whether the player completed the level without losing any lives.</summary>
+        public bool isPerfect;
+
+        /// <summary>Whether the player leveled up from this level's XP.</summary>
+        public bool didLevelUp;
+
+        /// <summary>The player's new level (relevant if didLevelUp is true).</summary>
+        public int newPlayerLevel;
+    }
+}

--- a/Client/Assets/Scripts/Managers/GamificationManager.cs.meta
+++ b/Client/Assets/Scripts/Managers/GamificationManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cffba2fb566d14dbfab1e4a101fa7872

--- a/Client/Assets/Scripts/Managers/UIManager.cs
+++ b/Client/Assets/Scripts/Managers/UIManager.cs
@@ -34,6 +34,12 @@ namespace Managers
         [SerializeField] private Button victoryMenuButton;
         [SerializeField] private List<GameObject> victoryStars;
 
+        [Header("Victory Panel - Gamification")]
+        [SerializeField] private TextMeshProUGUI victoryXPText;
+        [SerializeField] private TextMeshProUGUI victoryCoinsText;
+        [SerializeField] private GameObject victoryLevelUpBadge;
+        [SerializeField] private TextMeshProUGUI victoryLevelUpText;
+
         [Header("Quiz Panel (to hide on game end)")]
         [SerializeField] private GameObject quizPanel;
 
@@ -126,12 +132,13 @@ namespace Managers
         }
 
         /// <summary>
-        /// Shows the Victory panel with score, stars, and navigation options.
+        /// Shows the Victory panel with score, stars, gamification rewards, and navigation options.
         /// </summary>
         /// <param name="score">The player's score for this level.</param>
         /// <param name="starsEarned">Number of stars earned (1-3).</param>
         /// <param name="hasNextLevel">Whether there's a next level available.</param>
-        public void ShowVictoryScreen(int score, int starsEarned, bool hasNextLevel)
+        /// <param name="rewards">Gamification rewards earned from this level.</param>
+        public void ShowVictoryScreen(int score, int starsEarned, bool hasNextLevel, LevelRewards rewards = default)
         {
             Debug.Log($"Displaying Victory screen - Score: {score}, Stars: {starsEarned}");
 
@@ -162,6 +169,27 @@ namespace Managers
                             victoryStars[i].SetActive(i < starsEarned);
                         }
                     }
+                }
+
+                // Update gamification reward displays
+                if (victoryXPText != null)
+                {
+                    victoryXPText.text = $"+{rewards.xpEarned} XP";
+                }
+
+                if (victoryCoinsText != null)
+                {
+                    victoryCoinsText.text = $"+{rewards.coinsEarned}";
+                }
+
+                if (victoryLevelUpBadge != null)
+                {
+                    victoryLevelUpBadge.SetActive(rewards.didLevelUp);
+                }
+
+                if (victoryLevelUpText != null && rewards.didLevelUp)
+                {
+                    victoryLevelUpText.text = $"Niveau {rewards.newPlayerLevel} !";
                 }
 
                 // Wire up buttons

--- a/Client/Assets/Scripts/UI/MainMenuUi.cs
+++ b/Client/Assets/Scripts/UI/MainMenuUi.cs
@@ -1,4 +1,5 @@
 using Managers;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -6,7 +7,7 @@ namespace UI
 {
     /// <summary>
     /// Main menu UI controller.
-    /// Handles button clicks and level selection.
+    /// Handles button clicks, level selection, and gamification stat display.
     /// </summary>
     public class MainMenuUI : MonoBehaviour
     {
@@ -19,9 +20,23 @@ namespace UI
         [SerializeField] private int startingLevel = 1;
         [SerializeField] private bool autoSelectHighestLevel = false;
 
+        [Header("Gamification Display")]
+        [SerializeField] private TextMeshProUGUI playerLevelText;
+        [SerializeField] private Slider xpProgressBar;
+        [SerializeField] private TextMeshProUGUI xpProgressText;
+        [SerializeField] private TextMeshProUGUI coinCountText;
+        [SerializeField] private TextMeshProUGUI streakText;
+
         private void Start()
         {
             SetupButtons();
+            RefreshGamificationDisplay();
+        }
+
+        private void OnEnable()
+        {
+            // Refresh stats every time the menu becomes visible (e.g. returning from a level)
+            RefreshGamificationDisplay();
         }
 
         private void SetupButtons()
@@ -35,6 +50,49 @@ namespace UI
             if (quitButton != null)
                 quitButton.onClick.AddListener(OnQuitClick);
         }
+
+        #region Gamification Display
+
+        /// <summary>
+        /// Updates all gamification UI elements with current values from GamificationManager.
+        /// Safe to call even if GamificationManager or UI elements are not assigned.
+        /// </summary>
+        private void RefreshGamificationDisplay()
+        {
+            if (GamificationManager.Instance == null)
+            {
+                return;
+            }
+
+            var gm = GamificationManager.Instance;
+
+            if (playerLevelText != null)
+            {
+                playerLevelText.text = $"Nv. {gm.PlayerLevel}";
+            }
+
+            if (xpProgressBar != null)
+            {
+                xpProgressBar.value = (float)gm.XPInCurrentLevel / gm.XPRequiredForLevel;
+            }
+
+            if (xpProgressText != null)
+            {
+                xpProgressText.text = $"{gm.XPInCurrentLevel} / {gm.XPRequiredForLevel} XP";
+            }
+
+            if (coinCountText != null)
+            {
+                coinCountText.text = $"{gm.EcoCoins}";
+            }
+
+            if (streakText != null)
+            {
+                streakText.text = gm.GetStreakDisplayText();
+            }
+        }
+
+        #endregion
 
         /// <summary>
         /// Called when the Play button is clicked.


### PR DESCRIPTION
## Summary

Implements the full gamification core system (ME-23) with three sub-features:

- **XP System (ME-24)**: +10 XP per correct answer, +50 level completion bonus, +30 perfect bonus, streak multiplier (1.0x–2.0x)
- **EcoCoins (ME-22)**: +5 per level, +10 perfect bonus, +2 per streak day. `SpendCoins()` API ready for future shop
- **Daily Streak (ME-21)**: Auto-detected on startup via date comparison, resets if a day is missed, awards coin bonuses and XP multiplier

## Changes

### New files
- `GamificationManager.cs` — Singleton manager with PlayerPrefs persistence, events (`OnXPGained`, `OnLevelUp`, `OnCoinsEarned`, `OnStreakUpdated`), and `LevelRewards` struct

### Modified files
- `GameManager.cs` — Added `gamificationManager` reference, XP on correct answer, level rewards + star persistence in `WinLevel()`, gamification reset in `ResetProgress()`
- `UIManager.cs` — Added XP text, coins text, level-up badge/text to victory screen
- `MainMenuUI.cs` — Added gamification display (player level, XP bar, coin count, streak), auto-refreshes on `OnEnable()`
- `BootManager.cs` — Added GamificationManager verification
- Unity scenes (Boot, Game, MainMenu) — Wired all new GameObjects and references

### Also wired
- `LevelScoreManager.SaveLevelStars()` was dead code — now called in `WinLevel()`

## Reward Values

| Reward | Amount |
|--------|--------|
| Correct answer | +10 XP (base) |
| Level completion | +50 XP (base) |
| Perfect bonus | +30 XP + 10 coins |
| EcoCoins per level | +5 |
| Streak coin bonus | +2 per streak day |
| Streak XP multiplier | 1.0x + 0.1x/day (max 2.0x) |
| Level up threshold | 100 XP per level |

Closes ME-24, ME-22, ME-21, ME-23